### PR TITLE
Require absolute path for locallib.php

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-require_once('locallib.php');
+require_once($CFG->dirroot.'/blocks/advnotifications/locallib.php');
 
 global $CFG;
 


### PR DESCRIPTION
When requiring a file, the full path should be specified. As it is right now, there are cases where locallib.php is not included as expected; specifying the full path fixes this.

The case where we saw this issue was in calling the admin_get_root() function in lib/adminlib.php, which builds the admin settings tree, thereby including the settings.php file for every installed plugin. In this situation, require_once('locallib.php') is skipped, and an error is then encountered when attempting to call get_date_formats(): the function is undefined. Using the absolute path here resolves this problem.

For more information, see the best practices guidelines for requiring/including in Moodle: https://moodledev.io/general/development/policies/codingstyle#require--include